### PR TITLE
Added hashie gem dependency into gemspec. 

### DIFF
--- a/qiita.gemspec
+++ b/qiita.gemspec
@@ -23,4 +23,5 @@ desc
   gem.add_dependency 'faraday', '~> 0.8'
   gem.add_dependency 'faraday_middleware', '~> 0.8'
   gem.add_dependency 'json', '~> 1.7'
+  gem.add_dependency 'hashie', '~> 1.2'
 end


### PR DESCRIPTION
FaradayMiddleware::Mashify requires hashie/mash.
but faraday_middleware gem doesn't include it in production.
(see also: https://github.com/pengwynn/faraday_middleware/blob/feedd2f97531a05c4b1b95b75f9dcd64c72e9645/faraday_middleware.gemspec#L7)
