### PR TITLE
Fix API doc method name

### DIFF
--- a/doc/client.md
+++ b/doc/client.md
@@ -142,7 +142,7 @@ client.connection.response :logger
 ### Qiita::Client#delete_project(id, params = nil, headers = nil)
 特定のプロジェクトを削除します。
 
-### Qiita::Client#update_project(id, params = nil, headers = nil)
+### Qiita::Client#patch_project(id, params = nil, headers = nil)
 特定のプロジェクトを編集します。
 
 ### Qiita::Client#create_expanded_template(params = nil, headers = nil)


### PR DESCRIPTION
What

* Fix `doc/client.md` API method name

Why

* There is no method called `update_project`

Ref

https://github.com/increments/qiita-rb/blob/871fefee1367e2547711e7822d0aa241a94736c7/lib/qiita/resource_based_methods.rb#L216