### PR TITLE
Support Faraday v1 and v2

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -6,13 +6,22 @@ on:
 
 jobs:
   rspec:
+    name: Faraday ${{ matrix.faraday }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        faraday:
+          - ~> 0.17
+          - ~> 1.0
+          - ~> 2.0
+    env:
+      FARADAY_VERSION: ${{ matrix.faraday }}
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0.0'
           bundler-cache: true
-      - run: gem install bundler -v '< 2.0'
+      - run: gem install bundler
       - run: bundle install
       - run: bundle exec rake spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Support Faraday v1 and v2
+
 ## v1.4.0
 
 - Migrate CI/CD platform from Travis CI to GitHub Actions

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,12 @@
 source 'https://rubygems.org'
 
+# Support Faraday 0.x, 1.x and 2.x
+faraday_version = ENV.fetch('FARADAY_VERSION', '~> 2.0')
+gem 'faraday', faraday_version
+
+if faraday_version.start_with?(/~> (0|1)/)
+  gem 'faraday_middleware'
+end
+
 # Specify your gem's dependencies in qiita.gemspec
 gemspec

--- a/lib/qiita.rb
+++ b/lib/qiita.rb
@@ -2,7 +2,7 @@ require "active_support/core_ext/object/blank"
 require "active_support/core_ext/string/inflections"
 require "active_support/core_ext/string/strip"
 require "faraday"
-require "faraday_middleware"
+require "faraday_middleware" if Faraday::VERSION.start_with?(/0|1/)
 require "json"
 require "rack/utils"
 require "rainbow"

--- a/qiita.gemspec
+++ b/qiita.gemspec
@@ -16,8 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
-  spec.add_dependency "faraday", "~> 0.9"
-  spec.add_dependency "faraday_middleware"
+  spec.add_dependency "faraday", ">= 0.17", "< 3.0"
   spec.add_dependency "rack"
   spec.add_dependency "rainbow"
   spec.add_dependency "rouge"
@@ -27,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "webmock", "1.20.4"
+  spec.add_development_dependency "webmock", "~> 3"
 end

--- a/spec/qiita/client_spec.rb
+++ b/spec/qiita/client_spec.rb
@@ -341,6 +341,10 @@ describe Qiita::Client do
       204
     end
 
+    let(:response_hash) do
+      nil
+    end
+
     include_examples "valid condition"
     include_examples "sends request with JSON-encoded body"
   end
@@ -360,6 +364,10 @@ describe Qiita::Client do
 
     let(:status_code) do
       204
+    end
+
+    let(:response_hash) do
+      nil
     end
 
     include_examples "valid condition"


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the repository license.
-->

Now, Faraday versions are 0.1x, 1.x and 2.x. I added faraday v1 and v2.


Faraday latest released

- Sep 13, 2023 [v2.7.11](https://github.com/lostisland/faraday/releases/tag/v2.7.11)
- Jan 19, 2023 [v1.10.3](https://github.com/lostisland/faraday/releases/tag/v1.10.3)
- Nov 5, 2022 [v0.17.6 ](https://github.com/lostisland/faraday/releases/tag/v0.17.6)