### PR TITLE
Use hash for github action

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -11,8 +11,8 @@ jobs:
       matrix:
         ruby-version: ['3.2', '3.3', '3.4']
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: ruby/setup-ruby@13e7a03dc3ac6c3798f4570bfead2aed4d96abfb # v1.244.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Require Ruby 3.2.0 or higher
+- Pin github actions
 
 ## v1.5.0
 


### PR DESCRIPTION
<!--
By contributing your code to this repository, you are deemed to agree to license your contribution under the MIT License.
-->

## What

- Pin github actions

## Refs

[GitHub Action supply chain attack: reviewdog/action-setup | Wiz Blog](https://www.wiz.io/blog/new-github-action-supply-chain-attack-reviewdog-action-setup)